### PR TITLE
Fix to issue 9

### DIFF
--- a/src/WebSocketConnection.php
+++ b/src/WebSocketConnection.php
@@ -68,6 +68,9 @@ class WebSocketConnection implements EventEmitterInterface
         $this->messageBuffer = $mb;
 
         $stream->on('data', [$mb, 'onData']);
+        $stream->on('close', function () {
+            $this->emit('close', [1006, $this, '']);
+        });
     }
 
     public function send($data)


### PR DESCRIPTION
When the WebSocketConnection does not forward the close events of the underlying stream to the WebSocketConnection's listeners this can lead to memory leaks.

I added a close event with reason code 1006 (closed abnormally) as a response to the underlying stream issuing a close event.